### PR TITLE
Add RSS feed

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -1,0 +1,28 @@
+---
+layout: null
+---
+
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0">
+  <channel>
+    <title>{{ site.title }}</title>
+    <link>{{ site.url }}</link>
+    <description>{{ site.description }}</description>
+    <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
+    {% for post in site.posts %}
+    <item>
+      <title>{{ post.title }}</title>
+      <link>
+        {{ post.url | prepend: site.url }}
+      </link>
+      <description>
+        {{ post.content | escape | truncate: '400' }}
+      </description>
+      <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
+      <guid>
+        {{ post.url | prepend: site.url }}
+      </guid>
+    </item>
+    {% endfor %}
+  </channel>
+</rss>


### PR DESCRIPTION
This PR adds an RSS feed template as per https://jekyllrb.com/tutorials/convert-site-to-jekyll/#10-rss-feed

Tested locally and confirmed the feed renders properly in Firefox.

Closes #21 
