### PR TITLE
Feature/page title

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
-    <title>{{ site.title | default: site.github.repository_name }} by {{ site.github.owner_name }}</title>
+	<title>{{ page.title }} - {{ site.title | default: site.github.repository_name }} by {{ site.github.owner_name }}</title>
     <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
     <style>
     figure {

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
-	<title>{{ page.title }} - {{ site.title | default: site.github.repository_name }} by {{ site.github.owner_name }}</title>
+	<title>{{ page.title }} - {{ site.title | default: site.github.repository_name }}</title>
     <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
     <style>
     figure {


### PR DESCRIPTION
* Add article title to the beginning of page title.
* Remove stray "by" suffix in page title.
    + This seems automatically added or generated from some template, but is not used at all.
      I think this can be (and should be) removed.

Now generated page titles are "some_article_title - Gfx-rs nuts and bolts"
(previously titles were "Gfx-rs nuts and bolts by" for all articles).

Solves #27.