### PR TITLE
Fix 0.9 formatting

### DIFF
--- a/_posts/2021-07-16-release-0.9-future.md
+++ b/_posts/2021-07-16-release-0.9-future.md
@@ -22,7 +22,7 @@ See [gfx-rs changelog](https://github.com/gfx-rs/gfx/blob/master/CHANGELOG.md#ha
 
 `wgpu` performance is still a vital target for us, so we have done work on improving the overhead of resource tracking. We've reduced unnecisary overhead through only doing stateful tracking for resources that have complex states. These changes were made from benchmarks of Gecko's WebGPU implemention which showed that tracking was a bottleneck. You can read more about it [#1413](https://github.com/gfx-rs/wgpu/issues/1413).
 
-## `wgpu` Family Reunion, Relicense, and the Future
+## wgpu Family Reunion, Relicense, and the Future
 
 `wgpu` has had a number of large internal changes which are laying the future for wgpu to be a safe, efficient, and portable api for doing cross-platform graphics.
 


### PR DESCRIPTION
Code inside of a title ended up looking super weird, this removes it.

![image](https://user-images.githubusercontent.com/7861353/125832835-9aa20c55-9fbb-46d9-b696-de23b9bf63ff.png)
