### PR TITLE
Fix link syntax in 2021-10-07-release-0.11

### DIFF
--- a/_posts/2021-10-07-release-0.11.md
+++ b/_posts/2021-10-07-release-0.11.md
@@ -5,16 +5,16 @@ title: Release of wgpu v0.11 and naga v0.7
 
 gfx-rs community's goal is to make graphics programming in Rust easy, fast, and reliable. Our main projects are:
 
-  - [wgpu](wgpu) is built on top of wgpu-hal and naga. It provides safety, accessibility, and portability for graphics applications.
-  - [naga](naga) translates shader programs between languages, including WGSL. It also provides shader validation and transformation, ensuring user code running on the GPU is safe and efficient.
+  - [wgpu] is built on top of wgpu-hal and naga. It provides safety, accessibility, and portability for graphics applications.
+  - [naga] translates shader programs between languages, including WGSL. It also provides shader validation and transformation, ensuring user code running on the GPU is safe and efficient.
 
-Following our release cadence of every few months, we rolled out 0.111 through all of the gfx-rs projects! See [wgpu v0.11 changelog](wgpu-changelog) and [naga v0.7 changelog](naga-changelog) for the details.
+Following our release cadence of every few months, we rolled out 0.111 through all of the gfx-rs projects! See [wgpu v0.11 changelog][wgpu-changelog] and [naga v0.7 changelog][naga-changelog] for the details.
 
 This is our second release using our pure rust graphics stack. We've made a significant progress with shader translation and squashed many bugs in both wgpu and the underlying abstraction layer.
 
 ## WebGL2
 
-Thanks to the help of @Zicklag for spearheading the work on the WebGL2 backend. Through modifying the use of our OpenGL ES backend, they got WebGL2 working on the web. The backend is still in beta, so please test it out and file bugs! See the [guide to running on the web](wasm-guide) for more information.
+Thanks to the help of @Zicklag for spearheading the work on the WebGL2 backend. Through modifying the use of our OpenGL ES backend, they got WebGL2 working on the web. The backend is still in beta, so please test it out and file bugs! See the [guide to running on the web][wasm-guide] for more information.
 
 The following shows one of Bevy's PBR examples running on the web.
 
@@ -30,21 +30,21 @@ A long standing point of confusion when using wgpu was that dropping the surface
 
 The most notable change was that @JCapucho, with the help of @jimb, completely rewrote the parsing of spirv's control flow. spirv has notably complex control flow which has a large number of complicated edge cases. After multiple reworks, we have settled on this new style of control flow graph parsing. If you input spirv into wgpu, this will mean that even more spirv, especially optimized spirv, will properly validate and convert. 
 
-See the [changelog](naga-changelog) for all the other awesome editions to naga.
+See the [changelog][naga-changelog] for all the other awesome editions to naga.
 
 ## Thank You!
 
-Thanks to the countless contributors that helped out with this release! `wgpu` and `naga`'s momentum is truely incredible due to everyone's contributions and we look forward to seeing the amazing places wgpu and naga will go as projects. If you are interested in helping, take a look at our [good-first-issues](wgpu-issues-good-first), our issues with [help wanted](wgpu-issues-help-wanted), or contact us on our [matrix chat](wgpu-matrix), we are always willing to help mentor first time and returning contributors.
+Thanks to the countless contributors that helped out with this release! `wgpu` and `naga`'s momentum is truely incredible due to everyone's contributions and we look forward to seeing the amazing places wgpu and naga will go as projects. If you are interested in helping, take a look at our [good-first-issues][wgpu-issues-good-first], our issues with [help wanted][wgpu-issues-help-wanted], or contact us on our [matrix chat][wgpu-matrix], we are always willing to help mentor first time and returning contributors.
 
 Additionally, thank you to all the users who report new issues, ask for enhancements, or test the git version of wgpu. Keep it coming!
 
 Happy rendering!
 
-[wgpu](https://github.com/gfx-rs/wgpu)
-[wgpu-changelog](https://github.com/gfx-rs/wgpu/blob/master/CHANGELOG.md#wgpu-011-2021-10-07)
-[naga](https://github.com/gfx-rs/naga)
-[naga-changelog](https://github.com/gfx-rs/naga/blob/master/CHANGELOG.md#v07-2021-10-07)
-[wasm-guide](https://github.com/gfx-rs/wgpu/wiki/Running-on-the-Web-with-WebGPU-and-WebGL)
-[wgpu-issues-good-first](https://github.com/gfx-rs/wgpu/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22good+first+issue%22)
-[wgpu-issues-help-wanted](https://github.com/gfx-rs/wgpu/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22help+wanted%22)
-[wgpu-matrix](https://matrix.to/#/#wgpu:matrix.org)
+[wgpu]: https://github.com/gfx-rs/wgpu
+[wgpu-changelog]: https://github.com/gfx-rs/wgpu/blob/master/CHANGELOG.md#wgpu-011-2021-10-07
+[naga]: https://github.com/gfx-rs/naga
+[naga-changelog]: https://github.com/gfx-rs/naga/blob/master/CHANGELOG.md#v07-2021-10-07
+[wasm-guide]: https://github.com/gfx-rs/wgpu/wiki/Running-on-the-Web-with-WebGPU-and-WebGL
+[wgpu-issues-good-first]: https://github.com/gfx-rs/wgpu/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22good+first+issue%22
+[wgpu-issues-help-wanted]: https://github.com/gfx-rs/wgpu/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22help+wanted%22
+[wgpu-matrix]: https://matrix.to/#/#wgpu:matrix.org


### PR DESCRIPTION
Markdown footnote links need to be written with square brackets at the reference, and `[label]: url` at the definition. The existing version interprets all the identifiers as nonexistent relative links.