### PR TITLE
Not Microsoft but Intel

### DIFF
--- a/_posts/2021-12-25-this-year.md
+++ b/_posts/2021-12-25-this-year.md
@@ -41,6 +41,6 @@ This includes guarding against out-of-bounds accesses on arrays, buffers, and te
 
 One big project that hasn't landed is the removal of "hubs". This is a purely internal change, but a grand one. It would streamline our policy of locking internal data and allow the whole infrastructure to scale better with more elaborate user workloads. We hope to see it coming in 2022.
 
-Another missing piece is DX11 backend. We know it's much needed, and it was the only regression from the _wgpu-hal_ port. This becomes especially important now as Windows stopped supporting DX12 on Intel Haswell GPUs.
+Another missing piece is DX11 backend. We know it's much needed, and it was the only regression from the _wgpu-hal_ port. This becomes especially important now as Intel stopped supporting DX12 on its Haswell GPUs.
 
 Overall, there's been a lot of good quality contributions, and this list by no means can describe the depth of it. We greatly appreciate all the improvements and would love to shout out about your work at the earliest opportunity. Big thanks for everybody involved!


### PR DESCRIPTION
Source: https://www.tomshardware.com/news/intel-disables-directx-12-on-haswell